### PR TITLE
fix: remove demilitarized_nation in the event

### DIFF
--- a/events/japan_events/treaty_of_sanfransico_events.txt
+++ b/events/japan_events/treaty_of_sanfransico_events.txt
@@ -32,5 +32,6 @@ treaty_of_san_francisco.1 = {
 			country = C:USA
 			type = defensive_pact
 		}
+		C:JAP = {remove_modifier = demilitarized_nation}
 	}
 }


### PR DESCRIPTION
The event should remove the modifier demilitarized_nation for japan